### PR TITLE
Update PsrLogger to make it the same with the last version of PSR

### DIFF
--- a/src/PsrLogger.php
+++ b/src/PsrLogger.php
@@ -165,7 +165,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function emergency($message, array $context = [])
+    public function emergency(Stringable|string $message, array $context = []): void
     {
         $this->log(Logger::EMERGENCY, $message, $context);
     }
@@ -183,7 +183,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function alert($message, array $context = [])
+    public function alert(string|\Stringable $message, array $context = []): void;
     {
         $this->log(Logger::ALERT, $message, $context);
     }
@@ -201,7 +201,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function critical($message, array $context = [])
+    public function critical(string|\Stringable $message, array $context = []): void;
     {
         $this->log(Logger::CRITICAL, $message, $context);
     }
@@ -219,7 +219,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function error($message, array $context = [])
+    public function error(string|\Stringable $message, array $context = []): void;
     {
         $this->log(Logger::ERROR, $message, $context);
     }
@@ -237,7 +237,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function warning($message, array $context = [])
+    public function warning(string|\Stringable $message, array $context = []): void;
     {
         $this->log(Logger::WARNING, $message, $context);
     }
@@ -255,7 +255,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function notice($message, array $context = [])
+    public function notice(string|\Stringable $message, array $context = []): void;
     {
         $this->log(Logger::NOTICE, $message, $context);
     }
@@ -273,7 +273,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function info($message, array $context = [])
+    public function info(string|\Stringable $message, array $context = []): void;
     {
         $this->log(Logger::INFO, $message, $context);
     }
@@ -291,7 +291,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function debug($message, array $context = [])
+    public function debug(string|\Stringable $message, array $context = []): void;
     {
         $this->log(Logger::DEBUG, $message, $context);
     }
@@ -368,7 +368,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * @return void
      * @throws InvalidArgumentException
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, string|\Stringable $message, array $context = []): void;
     {
         $this->validateLogLevel($level);
         $options = [];


### PR DESCRIPTION
Fatal error: Declaration of Google\Cloud\Logging\PsrLogger::emergency($message, array $context = []) must be compatible with Psr\Log\LoggerInterface::emergency(Stringable|string $message, array $context = []): void in /var/www/html/vendor/google/cloud-logging/src/PsrLogger.php on line 167

**PLEASE READ THIS ENTIRE MESSAGE**

Hello, and thank you for your contribution! Please note that this repository is
a read-only split of `googleapis/google-cloud-php`. As such, we are
unable to accept pull requests to this repository.

We welcome your pull request and would be happy to consider it for inclusion in
our library if you follow these steps:

* Clone the parent client library repository:

```sh
$ git clone git@github.com:googleapis/google-cloud-php.git
```

* Move your changes into the correct location in that library. Library code
belongs in `Logging/src`, and tests in `Logging/tests`.

* Push the changes in a new branch to a fork, and open a new pull request
[here](https://github.com/googleapis/google-cloud-php).

Thanks again, and we look forward to seeing your proposed change!

The Google Cloud PHP team
