### PR TITLE
feat: google/cloud-logging is now compatible with psr/log >=v3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,12 @@
         "opis/closure": "^3"
     },
     "provide": {
-        "psr/log-implementation": "1.0|2.0"
+        "psr/log-implementation": "3.0"
     },
     "suggest": {
         "ext-grpc": "The gRPC extension enables use of the performant gRPC transport",
         "ext-protobuf": "Provides a significant increase in throughput over the pure PHP protobuf implementation. See https://cloud.google.com/php/grpc for installation instructions.",
         "psr/log": "For using the PSR logger. Currently supports versions 1 and 2."
-    },
-    "conflict": {
-        "psr/log": ">=3"
     },
     "extra": {
         "component": {

--- a/src/PsrLogger.php
+++ b/src/PsrLogger.php
@@ -168,7 +168,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = []): void
     {
         $this->log(Logger::EMERGENCY, $message, $context);
     }
@@ -186,7 +186,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = []): void
     {
         $this->log(Logger::ALERT, $message, $context);
     }
@@ -204,7 +204,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = []): void
     {
         $this->log(Logger::CRITICAL, $message, $context);
     }
@@ -222,7 +222,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function error($message, array $context = [])
+    public function error($message, array $context = []): void
     {
         $this->log(Logger::ERROR, $message, $context);
     }
@@ -240,7 +240,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = []): void
     {
         $this->log(Logger::WARNING, $message, $context);
     }
@@ -258,7 +258,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = []): void
     {
         $this->log(Logger::NOTICE, $message, $context);
     }
@@ -276,7 +276,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function info($message, array $context = [])
+    public function info($message, array $context = []): void
     {
         $this->log(Logger::INFO, $message, $context);
     }
@@ -294,7 +294,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function debug($message, array $context = [])
+    public function debug($message, array $context = []): void
     {
         $this->log(Logger::DEBUG, $message, $context);
     }
@@ -371,7 +371,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * @return void
      * @throws \InvalidArgumentException
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->validateLogLevel($level);
         $options = [];


### PR DESCRIPTION
This Upgrade of the library makes it compliant with the `psr/log` version 3 and above.
The version of 3 adds return types to different logging level logging functions e.g: `emergency`.