### PR TITLE
google/cloud-logging is now compatible with psr/log >=v3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "google/cloud-core": "^1.52.7",
         "google/gax": "^1.24.0"
     },
@@ -21,15 +21,12 @@
         "opis/closure": "^3"
     },
     "provide": {
-        "psr/log-implementation": "1.0|2.0"
+        "psr/log-implementation": "3.0"
     },
     "suggest": {
         "ext-grpc": "The gRPC extension enables use of the performant gRPC transport",
         "ext-protobuf": "Provides a significant increase in throughput over the pure PHP protobuf implementation. See https://cloud.google.com/php/grpc for installation instructions.",
         "psr/log": "For using the PSR logger. Currently supports versions 1 and 2."
-    },
-    "conflict": {
-        "psr/log": ">=3"
     },
     "extra": {
         "component": {

--- a/src/PsrLogger.php
+++ b/src/PsrLogger.php
@@ -168,7 +168,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function emergency($message, array $context = [])
+    public function emergency(string|\Stringable $message, array $context = []): void
     {
         $this->log(Logger::EMERGENCY, $message, $context);
     }
@@ -186,7 +186,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function alert($message, array $context = [])
+    public function alert(string|\Stringable $message, array $context = []): void
     {
         $this->log(Logger::ALERT, $message, $context);
     }
@@ -204,7 +204,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function critical($message, array $context = [])
+    public function critical(string|\Stringable $message, array $context = []): void
     {
         $this->log(Logger::CRITICAL, $message, $context);
     }
@@ -222,7 +222,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function error($message, array $context = [])
+    public function error(string|\Stringable $message, array $context = []): void
     {
         $this->log(Logger::ERROR, $message, $context);
     }
@@ -240,7 +240,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function warning($message, array $context = [])
+    public function warning(string|\Stringable $message, array $context = []): void
     {
         $this->log(Logger::WARNING, $message, $context);
     }
@@ -258,7 +258,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function notice($message, array $context = [])
+    public function notice(string|\Stringable $message, array $context = []): void
     {
         $this->log(Logger::NOTICE, $message, $context);
     }
@@ -276,7 +276,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function info($message, array $context = [])
+    public function info(string|\Stringable $message, array $context = []): void
     {
         $this->log(Logger::INFO, $message, $context);
     }
@@ -294,7 +294,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      *        for the available options.
      * @return void
      */
-    public function debug($message, array $context = [])
+    public function debug(string|\Stringable $message, array $context = []): void
     {
         $this->log(Logger::DEBUG, $message, $context);
     }
@@ -371,7 +371,7 @@ class PsrLogger implements LoggerInterface, \Serializable
      * @return void
      * @throws \InvalidArgumentException
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, string|\Stringable $message, array $context = []): void
     {
         $this->validateLogLevel($level);
         $options = [];


### PR DESCRIPTION
This Upgrade makes the library compliant with the [psr/log](https://github.com/php-fig/log/blob/3.0.0/src/LoggerInterface.php) version 3 and above.
The version 3 adds return types to different logging functions.

The library now requires php 8.0 or above as the union types are available starting from that version.